### PR TITLE
Fix dev script to use pnpm parallel workspace run

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "version": "0.0.0",
   "scripts": {
-    "dev": "concurrently -c \"auto\" -n \"api,web\" \"pnpm --filter api dev\" \"pnpm --filter web dev\"",
+    "dev": "pnpm -r --parallel --filter ./apps/api --filter ./apps/web dev",
     "build": "pnpm -r --filter ./... run build",
     "lint": "pnpm -r --filter ./... run lint",
     "format": "pnpm -r --filter ./... run format",


### PR DESCRIPTION
## Summary
- replace the root dev script to use pnpm's recursive parallel runner instead of concurrently
- rely on pnpm to launch the api and web dev servers to avoid Windows cmd.exe spawn issues

## Testing
- pnpm dev *(fails: missing workspace installs in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0570801d48322987511981c1c703c