### PR TITLE
Ensure pnpm is available via corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "type": "module",
   "version": "0.0.0",
+  "packageManager": "pnpm@8.15.4",
   "scripts": {
+    "preinstall": "corepack enable && corepack prepare pnpm@8.15.4 --activate",
     "dev": "pnpm -r --parallel --filter ./apps/api --filter ./apps/web dev",
     "build": "pnpm -r --filter ./... run build",
     "lint": "pnpm -r --filter ./... run lint",


### PR DESCRIPTION
## Summary
- declare the pnpm workspace manager version at the repository root
- enable pnpm automatically during installation so build scripts work without a global install

## Testing
- not run (network restriction prevented installing pnpm via corepack)


------
https://chatgpt.com/codex/tasks/task_e_68e05adfc0b88322ab51bfac4ce56305