### PR TITLE
fix: align API tsconfig with NodeNext requirements

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext"
   },
+  "include": ["src"],
   "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- set the API TypeScript build to emit NodeNext modules to match its resolution strategy
- scope the API compiler include list to the src directory so files are discovered during builds

## Testing
- pnpm --filter @innerbloom/api build *(fails: unable to download pnpm due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e05bcfb7788322a3d1214a20936954