### PR TITLE
fix: resolve shared package types without prebuild

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "exports": {
     ".": "./dist/index.js"
   },


### PR DESCRIPTION
## Summary
- point the shared package's types field at the source entry so TypeScript can consume it before build output exists

## Testing
- pnpm --filter ./apps/api build *(fails: corepack cannot download pnpm due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e05cf0879483228b8676d3db41ee26