### PR TITLE
chore: replace pnpm tooling with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Innerbloom Monorepo
 
-A minimal PNPM workspace for the Innerbloom gamification MVP. It ships with a TypeScript Express API and a Vite + React client that share linting, formatting, and TypeScript foundations.
+A minimal npm workspace for the Innerbloom gamification MVP. It ships with a TypeScript Express API and a Vite + React client that share linting, formatting, and TypeScript foundations.
 
 ## Prerequisites
 
 - Node.js 20 LTS (`nvm use` with the provided `.nvmrc`)
-- [PNPM](https://pnpm.io/) 8+
+- npm 10+
 
 ## Getting Started
 
 1. Install dependencies:
    ```bash
-   pnpm install
+   npm install
    ```
 2. Copy environment templates and adjust as needed:
    ```bash
@@ -20,20 +20,20 @@ A minimal PNPM workspace for the Innerbloom gamification MVP. It ships with a Ty
    ```
 3. Start both apps with one command:
    ```bash
-   pnpm dev
+   npm run dev local
    ```
 
 ## Available Scripts
 
 | Command | Description |
 | --- | --- |
-| `pnpm dev` | Runs API and web app together with live reload. |
-| `pnpm build` | Builds every workspace package and app in topological order. |
-| `pnpm lint` | Lints all workspaces with the shared ESLint rules. |
-| `pnpm format` | Checks formatting via Prettier across the repo. |
-| `pnpm test` | Executes Vitest suites in every workspace. |
+| `npm run dev local` | Runs API and web app together with live reload. |
+| `npm run build` | Builds every workspace package and app in topological order. |
+| `npm run lint` | Lints all workspaces with the shared ESLint rules. |
+| `npm run format` | Checks formatting via Prettier across the repo. |
+| `npm run test` | Executes Vitest suites in every workspace. |
 
-Each workspace also exposes local scripts (e.g. `pnpm --filter @innerbloom/api lint`).
+Each workspace also exposes local scripts (e.g. `npm run lint --workspace @innerbloom/api`).
 
 ## Environment Variables
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@innerbloom/shared": "workspace:*",
+    "@innerbloom/shared": "file:../../packages/shared",
     "cors": "^2.8.5",
     "dotenv": "^16.4.1",
     "express": "^4.18.2",
@@ -20,8 +20,8 @@
     "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {
-    "@innerbloom/config": "workspace:*",
-    "@innerbloom/tsconfig": "workspace:*",
+    "@innerbloom/config": "file:../../packages/config",
+    "@innerbloom/tsconfig": "file:../../packages/tsconfig",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/morgan": "^1.9.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,14 +11,14 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@innerbloom/shared": "workspace:*",
+    "@innerbloom/shared": "file:../../packages/shared",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.3"
   },
   "devDependencies": {
-    "@innerbloom/config": "workspace:*",
-    "@innerbloom/tsconfig": "workspace:*",
+    "@innerbloom/config": "file:../../packages/config",
+    "@innerbloom/tsconfig": "file:../../packages/tsconfig",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,24 @@
   "private": true,
   "type": "module",
   "version": "0.0.0",
-  "packageManager": "pnpm@8.15.4",
+  "packageManager": "npm@10.5.0",
+  "workspaces": {
+    "packages": [
+      "apps/api",
+      "apps/web",
+      "packages/config",
+      "packages/shared",
+      "packages/tsconfig"
+    ]
+  },
   "scripts": {
-    "preinstall": "corepack enable && corepack prepare pnpm@8.15.4 --activate",
-    "dev": "pnpm -r --parallel --filter ./apps/api --filter ./apps/web dev",
-    "build": "pnpm -r --filter ./... run build",
-    "lint": "pnpm -r --filter ./... run lint",
-    "format": "pnpm -r --filter ./... run format",
-    "test": "pnpm -r --filter ./... run test"
+    "dev": "npm run dev:local",
+    "dev:local": "concurrently \"npm run dev --workspace @innerbloom/api\" \"npm run dev --workspace @innerbloom/web\"",
+    "local": "node -e \"\"",
+    "build": "npm run build --workspaces --if-present",
+    "lint": "npm run lint --workspaces --if-present",
+    "format": "npm run format --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present"
   },
   "devDependencies": {
     "@types/node": "^20.11.17",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-packages:
-  - "apps/*"
-  - "packages/*"


### PR DESCRIPTION
## Summary
- switch the monorepo tooling from pnpm to npm workspaces and add combined dev scripts
- point app workspace dependencies at local package folders via file references
- refresh the README and remove the pnpm workspace manifest

## Testing
- not run (npm install blocked by 403 responses from the npm registry in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e06000d3c08322a4557b8a53fb990e