### PR TITLE
Fix TypeScript build config and improve dev workflow

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -8,7 +8,8 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,
-    "noEmit": true
+    "noEmit": false,
+    "outDir": "./dist/node"
   },
   "include": ["vite.config.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "npm run dev:local",
-    "dev:local": "concurrently \"npm run dev --workspace @innerbloom/api\" \"npm run dev --workspace @innerbloom/web\"",
+    "dev:local": "node scripts/dev.mjs",
     "local": "node -e \"\"",
     "build": "npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
@@ -23,7 +23,6 @@
     "@types/node": "^20.11.17",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "concurrently": "^8.2.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,59 @@
+import { spawn } from 'node:child_process';
+
+const commands = [
+  {
+    name: 'api',
+    command: 'npm run dev --workspace @innerbloom/api',
+  },
+  {
+    name: 'web',
+    command: 'npm run dev --workspace @innerbloom/web',
+  },
+];
+
+const children = new Set();
+let exitCode = 0;
+let exiting = false;
+
+const terminateAll = (signal) => {
+  if (exiting) return;
+  exiting = true;
+  for (const child of children) {
+    if (!child.killed) {
+      child.kill(signal);
+    }
+  }
+};
+
+for (const { command } of commands) {
+  const child = spawn(command, {
+    stdio: 'inherit',
+    shell: true,
+    env: process.env,
+  });
+
+  children.add(child);
+
+  child.on('exit', (code) => {
+    children.delete(child);
+
+    if (code && exitCode === 0) {
+      exitCode = code;
+      terminateAll('SIGINT');
+    }
+
+    if (children.size === 0) {
+      process.exit(exitCode);
+    }
+  });
+}
+
+process.on('SIGINT', () => {
+  exitCode = exitCode || 130;
+  terminateAll('SIGINT');
+});
+
+process.on('SIGTERM', () => {
+  exitCode = exitCode || 143;
+  terminateAll('SIGTERM');
+});


### PR DESCRIPTION
## Summary
- allow the web workspace TypeScript configs to build by enabling emission for the Vite config project and including Vitest globals for tests
- replace the `concurrently`-based dev script with a small Node runner so the local dev command works on Windows as well

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e067c0dcf48322918f29d4819f8516