### PR TITLE
Add Node types dependency for API build

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {
+    "@types/node": "^20.11.17",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/morgan": "^1.9.6",


### PR DESCRIPTION
## Summary
- add the `@types/node` dev dependency to the API workspace so TypeScript can resolve Node typings during the build

## Testing
- npm run build --workspace=@innerbloom/api

------
https://chatgpt.com/codex/tasks/task_e_68e07781d65483229a4ebae9b941137a