### PR TITLE
Fix API TypeScript type roots to find Node types

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -11,7 +11,11 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "types": ["node", "clerk__express"],
-    "typeRoots": ["./src/types", "../../node_modules/@types"]
+    "typeRoots": [
+      "./src/types",
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts"]


### PR DESCRIPTION
## Summary
- ensure the API TypeScript compiler checks both local and workspace node_modules for declaration packages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07e92e0ec8322bf4e23f608ff67a1